### PR TITLE
Fix async warnings

### DIFF
--- a/src/Octokit.Extensions/Caching/InMemoryCacheProvider.cs
+++ b/src/Octokit.Extensions/Caching/InMemoryCacheProvider.cs
@@ -16,6 +16,7 @@ namespace Octokit.Extensions
         }
         public async Task Add(CacheKey key, CacheEntry entry)
         {
+            await Task.CompletedTask;
             _cache.Set(key,entry);
         }
 
@@ -26,16 +27,19 @@ namespace Octokit.Extensions
 
         public async Task<bool> Exists(CacheKey key)
         {
+            await Task.CompletedTask;
            return _cache.TryGetValue(key,out _);
         }
 
         public async Task<CacheEntry> Get(CacheKey key)
         {
+            await Task.CompletedTask;
             return _cache.Get<CacheEntry>(key);
         }
 
         public async Task Remove(CacheKey key)
         {
+            await Task.CompletedTask;
             _cache.Remove(key);
         }
     }

--- a/src/Octokit.Extensions/Resiliency/ResilientPolicies.cs
+++ b/src/Octokit.Extensions/Resiliency/ResilientPolicies.cs
@@ -68,6 +68,7 @@ namespace Octokit.Extensions
            sleepDurationProvider: retryAttempt => TimeSpan.FromSeconds(Math.Pow(2, retryAttempt)),
            onRetryAsync: async (exception, retryCount) =>
            {
+               await Task.CompletedTask;
                _logger?.LogInformation("A {exception} has occurred with {message}. Will try again shortly.", "ApiException",exception.Message);
            });
 


### PR DESCRIPTION
Adds a whole bunch of `await Task.CompletedTask;` statements to fix async warnings.