### PR TITLE
Change from PackageLicenseUrl to PackageLicenseExpression

### DIFF
--- a/src/Octokit.Extensions/Octokit.Extensions.csproj
+++ b/src/Octokit.Extensions/Octokit.Extensions.csproj
@@ -13,7 +13,7 @@
     <RepositoryType>Git</RepositoryType>
     <Version>1.0.7</Version>
     <PackageTags>octokit</PackageTags>
-    <PackageLicenseUrl>https://github.com/mirsaeedi/octokit.net.Extensions/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageId>Octopus.Octokit.Net.Extensions</PackageId>
     <AssemblyName>Octokit.Extensions</AssemblyName>
     <RootNamespace>Octokit.Extensions</RootNamespace>


### PR DESCRIPTION
`PackageLicenseUrl` is deprecated. See https://learn.microsoft.com/en-us/nuget/reference/errors-and-warnings/nu5125