### PR TITLE
Add resiliency for github graphql connections

### DIFF
--- a/src/Octokit.Extensions.Tests.Integration/Helpers/Helper.cs
+++ b/src/Octokit.Extensions.Tests.Integration/Helpers/Helper.cs
@@ -21,4 +21,5 @@ public static class Helper
     });
 
     public static Credentials Credentials => _credentialsThunk.Value;
+    public static string Token => Environment.GetEnvironmentVariable("OCTOKIT_GITHUBPASSWORD");
 }

--- a/src/Octokit.Extensions.Tests.Integration/ResilientGitHubGraphQLClientTests.cs
+++ b/src/Octokit.Extensions.Tests.Integration/ResilientGitHubGraphQLClientTests.cs
@@ -1,0 +1,71 @@
+using System.Threading.Tasks;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace Octokit.Extensions.Tests.Integration
+{
+    public class ResilientGitHubGraphQLClientTests
+    {
+        [Fact]
+        public async Task MakesWrappedOctokitRequest()
+        {
+            var connection = new ResilientGitHubGraphQLConnectionFactory()
+                .Create(new GraphQL.ProductHeaderValue("Octokit.Extensions.Tests"), Helper.Token);
+
+            var query = GetQuery();
+
+            var json = await connection.Run(query);
+            var results = JObject.Parse(json);
+
+            Assert.Equal("octokit", results["data"]?["repository"]?["owner"]?["login"]?.Value<string>());
+            Assert.Equal("octokit.net", results["data"]?["repository"]?["name"]?.Value<string>());
+        }
+
+        private static string GetQuery()
+        {
+            var rawQuery = @"query { 
+  rateLimit {
+    limit
+    cost
+    remaining
+    resetAt
+  }
+  repository(owner: ""octokit"", name:""octokit.net"") { 
+    owner {
+      login
+    },
+    name
+  }
+}";
+            var cleanedUpQuery = rawQuery
+                .Replace("\n", "")
+                .Replace("\r", "")
+                .Replace("\"", "\\\"");
+            var query = $"{{\"query\": \"{cleanedUpQuery}\"}}";
+            return query;
+        }
+
+        [Fact(Skip = "Caching is not yet supported by GitHub GraphQL - see https://github.com/renovatebot/renovate/issues/11419#issuecomment-1030164500")]
+        public async Task MakesCachedWrappedOctokitRequest()
+        {
+            var connection = new ResilientGitHubGraphQLConnectionFactory()
+                .Create(new GraphQL.ProductHeaderValue("Octokit.Extensions.Tests"),
+                    Helper.Token,
+                    new InMemoryCacheProvider(),
+                    new ResilientPolicies().DefaultResilientPolicies);
+
+            var query = GetQuery();
+
+            var json = await connection.Run(query);
+            var results = JObject.Parse(json);
+
+            var remaining = results["data"]?["rateLimit"]?["remaining"]?.Value<string>();
+
+            var cachedJson = await connection.Run(query);
+            var cachedResults = JObject.Parse(cachedJson);
+            var cachedRemaining = cachedResults["data"]?["rateLimit"]?["remaining"]?.Value<string>();
+
+            Assert.Equal(remaining, cachedRemaining);
+        }
+    }
+}

--- a/src/Octokit.Extensions/Octokit.Extensions.csproj
+++ b/src/Octokit.Extensions/Octokit.Extensions.csproj
@@ -17,6 +17,7 @@
     <AssemblyName>Octokit.Extensions</AssemblyName>
     <RootNamespace>Octokit.Extensions</RootNamespace>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <NoWarn>1701;1702;NU5104</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -24,6 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="7.0.0" />
     <PackageReference Include="Octokit" Version="4.0.3" />
+    <PackageReference Include="Octokit.GraphQL" Version="0.1.9-beta" />
     <PackageReference Include="Polly" Version="7.2.3" />
   </ItemGroup>
 

--- a/src/Octokit.Extensions/ResilientGitHubGraphQLConnectionFactory.cs
+++ b/src/Octokit.Extensions/ResilientGitHubGraphQLConnectionFactory.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Net.Http;
+using Microsoft.Extensions.Logging;
+using Octokit.Internal;
+using Polly;
+using InMemoryCredentialStore = Octokit.GraphQL.Internal.InMemoryCredentialStore;
+
+namespace Octokit.Extensions
+{
+    public class ResilientGitHubGraphQLConnectionFactory
+    {
+        private readonly ILogger logger;
+
+        public ResilientGitHubGraphQLConnectionFactory(ILogger logger = null)
+        {
+            this.logger = logger;
+        }
+        
+        public Octokit.GraphQL.Connection Create(
+            GraphQL.ProductHeaderValue productHeaderValue,
+            string token,
+            ICacheProvider cacheProvider = null,
+            params IAsyncPolicy[] policies)
+        {
+            if (policies is null || policies.Length == 0)
+                policies = new ResilientPolicies(logger).DefaultResilientPolicies;
+
+            var policy = policies.Length > 1 
+                ? Policy.WrapAsync(policies) 
+                : policies[0];
+            
+            var connection = new Octokit.GraphQL.Connection(
+                productHeaderValue,
+                GraphQL.Connection.GithubApiUri,
+                new InMemoryCredentialStore(token),
+                new HttpClient(new MyHandler { InnerHandler = GetHttpHandlerChain(policy, cacheProvider) })
+            );
+
+            return connection;
+        }
+        
+        private HttpMessageHandler GetHttpHandlerChain(IAsyncPolicy policy, ICacheProvider cacheProvider)
+        {
+            var handler = HttpMessageHandlerFactory.CreateDefault();
+
+            handler = new GitHubResilientHandler(handler, policy, this.logger);
+
+            if (cacheProvider != null)
+            {
+                //handler = new HttpCacheHandler(handler,cacheProvider,logger); 
+                throw new NotImplementedException("GraphQL caching is not supported by GitHub yet");
+            }
+
+            return handler;
+        }
+    }
+
+    public class MyHandler : DelegatingHandler
+    {
+    }
+}


### PR DESCRIPTION
This is a reasonably naive copy of the resiliency implementation from the normal github client, but switched over to use the graphql connection instead.

Unfortunately caching is not supported by the github graphql endpoint, so that doesn't work, but mainly we want it for "invalid gateway" type errors anyway, so not a big concern.