### PR TITLE
Add logging for when we add to the cache

### DIFF
--- a/src/Octokit.Extensions/Caching/HttpCacheHandler.cs
+++ b/src/Octokit.Extensions/Caching/HttpCacheHandler.cs
@@ -82,6 +82,9 @@ namespace Octokit.Extensions
         {
             var primaryKey = new CacheKey(request.RequestUri);
             var entry = await CacheEntry.Create(response).ConfigureAwait(false);
+            _logger?.LogInformation("Caching response returned. ETAG: {etag}, URI:{URI}",
+                entry.ETag.Tag,
+                request.RequestUri.AbsolutePath);
             await _cache.Add(primaryKey, entry).ConfigureAwait(false);
         }
 


### PR DESCRIPTION
So we can have a better idea of why it's only finding 13 repos, rather than 315