### PR TITLE
Update to latest OctoVersion.Tool

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -63,7 +63,7 @@ else {
     $env:DOTNET_EXE = "$DotNetDirectory\dotnet.exe"
 }
 
-Write-Output "Microsoft (R) .NET SDK version $(& $env:DOTNET_EXE --version)"
+Write-Output "Microsoft (R) .NET Core SDK version $(& $env:DOTNET_EXE --version)"
 
 ExecSafe { & $env:DOTNET_EXE build $BuildProjectFile /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet }
 ExecSafe { & $env:DOTNET_EXE run --project $BuildProjectFile --no-build -- $BuildArguments }

--- a/build.sh
+++ b/build.sh
@@ -56,7 +56,7 @@ else
     export DOTNET_EXE="$DOTNET_DIRECTORY/dotnet"
 fi
 
-echo "Microsoft (R) .NET SDK version $("$DOTNET_EXE" --version)"
+echo "Microsoft (R) .NET Core SDK version $("$DOTNET_EXE" --version)"
 
 "$DOTNET_EXE" build "$BUILD_PROJECT_FILE" /nodeReuse:false /p:UseSharedCompilation=false -nologo -clp:NoSummary --verbosity quiet
 "$DOTNET_EXE" run --project "$BUILD_PROJECT_FILE" --no-build -- "$@"

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -46,8 +46,8 @@ class Build : NukeBuild
         .Before(Restore)
         .Executes(() =>
         {
-            SourceDirectory.GlobDirectories("**/bin", "**/obj", "**/TestResults").ForEach(DeleteDirectory);
-            EnsureCleanDirectory(ArtifactsDirectory);
+            SourceDirectory.GlobDirectories("**/bin", "**/obj", "**/TestResults").ForEach(x => x.DeleteDirectory());
+            ArtifactsDirectory.CreateOrCleanDirectory();
         });
 
     Target Restore => _ => _
@@ -82,7 +82,7 @@ class Build : NukeBuild
                 .SetFilter(TestFilter)
                 .EnableNoBuild()
                 .EnableNoRestore());
-            GlobFiles(SourceDirectory, "**/*.trx").ForEach(x => CopyFileToDirectory(x, ArtifactsDirectory));
+            SourceDirectory.GlobFiles("**/*.trx").ForEach(x => CopyFileToDirectory(x, ArtifactsDirectory));
         });
 
     Target Pack => _ => _
@@ -104,8 +104,8 @@ class Build : NukeBuild
         .TriggeredBy(Pack)
         .Executes(() =>
         {
-            EnsureExistingDirectory(LocalPackagesDirectory);
-            GlobFiles(ArtifactsDirectory, $"*.{OctoVersionInfo.FullSemVer}.nupkg")
+            LocalPackagesDirectory.CreateOrCleanDirectory();
+            ArtifactsDirectory.GlobFiles($"*.{OctoVersionInfo.FullSemVer}.nupkg")
                 .ForEach(x => CopyFileToDirectory(x, LocalPackagesDirectory));
         });
 

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -17,6 +17,6 @@
 
   <ItemGroup>
     <PackageDownload Include="NuGet.CommandLine" Version="[5.8.1]" />
-    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.164]" />
+    <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[0.3.164]" />
   </ItemGroup>
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -17,6 +17,6 @@
 
   <ItemGroup>
     <PackageDownload Include="NuGet.CommandLine" Version="[5.8.1]" />
-    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.11]" />
+    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.164]" />
   </ItemGroup>
 </Project>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -12,11 +12,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.2.1" />
+    <PackageReference Include="Nuke.Common" Version="7.0.6" />
   </ItemGroup>
 
   <ItemGroup>
     <PackageDownload Include="NuGet.CommandLine" Version="[5.8.1]" />
-    <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[0.3.164]" />
+    <PackageDownload Include="Octopus.OctoVersion.Tool" Version="[0.3.223]" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
We want to use the latest version (to get the latest OctoVersion fixes), but because of the way the PackageDownload references require a specific version, dependabot doesn't auto-update them.

Note: this project builds in TeamCity, rather than GitHub Actions, so the fixes aren't strictly required, it's more "just in case" we want to switch to GHA at some point.

~**Update**: :sadpanda: We cant do this yet, as we're waiting on https://github.com/nuke-build/nuke/pull/1104 being released in Nuke. We'll need to update that at the same time.
I've reached out to the author of Nuke to get an update.~