### PR TITLE
Bump Octokit.GraphQL to 0.4.0-beta

### DIFF
--- a/src/Octokit.Extensions/Octokit.Extensions.csproj
+++ b/src/Octokit.Extensions/Octokit.Extensions.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="10.0.10" />
     <PackageReference Include="Octokit" Version="14.0.0" />
-    <PackageReference Include="Octokit.GraphQL" Version="0.3.0-beta" />
+    <PackageReference Include="Octokit.GraphQL" Version="0.4.0-beta" />
     <PackageReference Include="Polly" Version="8.7.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Background

Moves `Octokit.GraphQL` to the latest beta (0.4.0-beta). #88 brought it to 0.3.0-beta; this picks up the newest release.

## Results

Bumps `Octokit.GraphQL` from 0.3.0-beta to 0.4.0-beta. Full solution restores and builds clean (0 errors/0 warnings).

## What changed in Octokit.GraphQL (0.3.0-beta → 0.4.0-beta)

Released 2024-04-09 ([full changelog](https://github.com/octokit/octokit.graphql.net/compare/v0.3.0-beta...v0.4.0-beta)):

- **Bug fix — `DatabaseId` fields changed from `int` → `long`** ([#312](https://github.com/octokit/octokit.graphql.net/pull/312)) across all model types, since GitHub's database IDs can exceed `int` range. Technically a breaking API change for any code reading a `DatabaseId` as `int`.
- **Model/schema regeneration** ([#315](https://github.com/octokit/octokit.graphql.net/pull/315)) — the bulk of the release; auto-generated `Model/*.cs` refreshed against the latest GitHub GraphQL schema.
- **New `Repository.PlannedFeatures` model** ([#316](https://github.com/octokit/octokit.graphql.net/pull/316)).
- Maintenance: CI workflow changes only (no package impact).
- **Dependencies unchanged** — still `Newtonsoft.Json 13.0.1`.

Octokit.Extensions itself compiles clean against 0.4.0-beta, so the `int→long` change doesn't affect its usage. The only thing to watch is downstream consumers of the shipped package that read a `DatabaseId` as `int`.
